### PR TITLE
Update package metadata to NextCocona

### DIFF
--- a/src/Cocona.Core/Cocona.Core.csproj
+++ b/src/Cocona.Core/Cocona.Core.csproj
@@ -7,7 +7,8 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet Package Information -->
-    <Description>Core component for Cocona. Micro-framework for .NET console application.</Description>
+    <PackageId>NextCocona.Core</PackageId>
+    <Description>Core component for NextCocona. Micro-framework for .NET console application.</Description>
   </PropertyGroup>
 
   <ItemGroup Condition="('$(TargetFramework)' == 'netstandard2.0') Or ('$(TargetFramework)' == 'netstandard2.1')">

--- a/src/Cocona.Lite/Cocona.Lite.csproj
+++ b/src/Cocona.Lite/Cocona.Lite.csproj
@@ -7,7 +7,8 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet Package Information -->
-    <Description>Lightweight version of Cocona. Micro-framework for .NET console application. Cocona makes it easy and fast to build console applications on .NET.</Description>
+    <PackageId>NextCocona.Lite</PackageId>
+    <Description>Lightweight version of NextCocona. Micro-framework for .NET console application. NextCocona makes it easy and fast to build console applications on .NET.</Description>
 
     <DefineConstants>COCONA_LITE</DefineConstants>
   </PropertyGroup>

--- a/src/Cocona/Cocona.csproj
+++ b/src/Cocona/Cocona.csproj
@@ -6,7 +6,8 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet Package Information -->
-    <Description>Micro-framework for .NET console application. Cocona makes it easy and fast to build console applications on .NET.</Description>
+    <PackageId>NextCocona</PackageId>
+    <Description>Micro-framework for .NET console application. NextCocona makes it easy and fast to build console applications on .NET.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,11 +9,11 @@
     <WarningsAsErrors>$(WarningsAsErrors);RS0030;Nullable</WarningsAsErrors>
 
     <!-- NuGet Package Information -->
-    <Description>Micro-framework for .NET console application. Cocona makes it easy and fast to build console applications on .NET.</Description>
-    <Authors>Mayuki Sawatari</Authors>
-    <Copyright>Copyright 2020-present Mayuki Sawatari</Copyright>
-    <PackageProjectUrl>https://github.com/mayuki/Cocona</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mayuki/Cocona</RepositoryUrl>
+    <Description>Micro-framework for .NET console application. NextCocona makes it easy and fast to build console applications on .NET.</Description>
+    <Authors>shunsock</Authors>
+    <Copyright>Copyright 2020-present Mayuki Sawatari, 2026-present shunsock</Copyright>
+    <PackageProjectUrl>https://github.com/shunsock/NextCocona</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/shunsock/NextCocona</RepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageTags>CommandLine CLI Framework Console</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Updated `Authors`, `Copyright`, `PackageProjectUrl`, `RepositoryUrl` in `Directory.Build.props` to reflect the NextCocona fork
- Added `PackageId` to each csproj: `NextCocona`, `NextCocona.Core`, `NextCocona.Lite`
- Updated `Description` text across all package files to reference NextCocona

Closes #1

## Test plan
- [ ] Verify `dotnet pack` produces packages with correct metadata (NextCocona identity, shunsock/NextCocona URLs)
- [ ] Confirm NuGet package IDs are `NextCocona`, `NextCocona.Core`, `NextCocona.Lite`

🤖 Generated with [Claude Code](https://claude.com/claude-code)