### PR TITLE
Add NuGet publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+---
+name: Publish to NuGet
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  DOTNET_NOLOGO: true
+  NUGET_SOURCE: https://api.nuget.org/v3/index.json
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - run: dotnet restore
+      - run: dotnet build -c Release --no-restore
+      - run: dotnet test -c Release --no-build
+
+      - name: Pack Cocona
+        run: >-
+          dotnet pack -c Release --no-build
+          -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+          --output ./artifacts ./src/Cocona/Cocona.csproj
+
+      - name: Pack Cocona.Core
+        run: >-
+          dotnet pack -c Release --no-build
+          -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+          --output ./artifacts ./src/Cocona.Core/Cocona.Core.csproj
+
+      - name: Pack Cocona.Lite
+        run: >-
+          dotnet pack -c Release --no-build
+          -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+          --output ./artifacts ./src/Cocona.Lite/Cocona.Lite.csproj
+
+      - name: Push to NuGet
+        run: >-
+          dotnet nuget push "./artifacts/*.nupkg"
+          --source ${{ env.NUGET_SOURCE }}
+          --api-key ${{ secrets.NUGET_API_KEY }}
+          --skip-duplicate
+
+      - name: Push symbols to NuGet
+        run: >-
+          dotnet nuget push "./artifacts/*.snupkg"
+          --source ${{ env.NUGET_SOURCE }}
+          --api-key ${{ secrets.NUGET_API_KEY }}
+          --skip-duplicate

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,5 @@
+extends: default
+rules:
+  line-length:
+    max: 120
+  truthy: disable


### PR DESCRIPTION
## Summary
- `v*` タグ push をトリガーに NuGet へ自動 publish するワークフローを追加
- Cocona, Cocona.Core, Cocona.Lite の 3 パッケージ + シンボルパッケージ (.snupkg) を生成・push
- `NUGET_API_KEY` シークレットを利用

## Test plan
- [ ] `NUGET_API_KEY` が GitHub Secrets に登録されていることを確認 (#6)
- [ ] `v*` タグを push して publish ワークフローが起動することを確認
- [ ] nuget.org にパッケージが公開されることを確認

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)