### PR TITLE
remove net6.0 target framework (#13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
 
       - run: dotnet restore

--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ $ dotnet add package Cocona.Lite
 ```
 
 ## Requirements
-- .NET 6 (Required to use Minimal API)
-- .NET 5
+- .NET 8
 - .NET Standard 2.0, 2.1
 
 ## Getting Started

--- a/src/Cocona.Core/Cocona.Core.csproj
+++ b/src/Cocona.Core/Cocona.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Cocona</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Cocona.Core/Internal/NullabilityInfoContextHelper.cs
+++ b/src/Cocona.Core/Internal/NullabilityInfoContextHelper.cs
@@ -12,13 +12,13 @@ internal class NullabilityInfoContextHelper
         Nullable = 2,
     }
 
-#if NET6_0_OR_GREATER
-        private readonly NullabilityInfoContext _context = new NullabilityInfoContext();
+#if NET8_0_OR_GREATER
+    private readonly NullabilityInfoContext _context = new NullabilityInfoContext();
 
-        public NullabilityState GetNullabilityState(ParameterInfo parameterInfo)
-        {
-            return (NullabilityState)_context.Create(parameterInfo).ReadState;
-        }
+    public NullabilityState GetNullabilityState(ParameterInfo parameterInfo)
+    {
+        return (NullabilityState)_context.Create(parameterInfo).ReadState;
+    }
 #else
     public NullabilityState GetNullabilityState(ParameterInfo parameterInfo)
     {

--- a/src/Cocona.Core/Internal/ThrowHelper.cs
+++ b/src/Cocona.Core/Internal/ThrowHelper.cs
@@ -5,8 +5,8 @@ internal static class ThrowHelper
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static void ThrowIfNull(object? argument, [System.Runtime.CompilerServices.CallerArgumentExpression("argument")] string? paramName = null)
     {
-#if NET6_0_OR_GREATER
-            ArgumentNullException.ThrowIfNull(argument, paramName);
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(argument, paramName);
 #else
         if (argument is null)
         {

--- a/src/Cocona.Lite/Cocona.Lite.csproj
+++ b/src/Cocona.Lite/Cocona.Lite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Cocona</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Cocona/Cocona.csproj
+++ b/src/Cocona/Cocona.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <ImplicitUsings>true</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/test/Cocona.Test/Cocona.Test.csproj
+++ b/test/Cocona.Test/Cocona.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Cocona\StrongNameKey.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
## Summary

- csproj 4ファイルから `net6.0` を TargetFrameworks から削除
- `#if NET6_0_OR_GREATER` を `#if NET8_0_OR_GREATER` に変更（netstandard 向け `#else` は維持）
- CI (`.github/workflows/ci.yml`) から `6.0.x` SDK インストールを削除
- README.md の Requirements から .NET 6, .NET 5 を削除

## Test plan

- [x] `dotnet format --verify-no-changes` — 変更対象ファイルのフォーマット違反なし
- [x] `dotnet build -c Release` — 全ターゲット（net8.0, netstandard2.0, netstandard2.1）でビルド成功
- [x] `dotnet test -c Release` — 全765テスト通過（Cocona.Test: 565, Cocona.Lite.Test: 200）
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)