### PR TITLE
add .NET 10 (LTS) target framework (#14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
 
       - run: dotnet restore
       - run: dotnet test -c Release --logger trx --results-directory ${{ github.workspace }}/test-results

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,8 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
+            10.0.x
 
       - name: Extract version from tag
         id: version

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ $ dotnet add package Cocona.Lite
 ```
 
 ## Requirements
+- .NET 10
 - .NET 8
 - .NET Standard 2.0, 2.1
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Cocona.Core/Cocona.Core.csproj
+++ b/src/Cocona.Core/Cocona.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Cocona</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Cocona.Lite/Cocona.Lite.csproj
+++ b/src/Cocona.Lite/Cocona.Lite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Cocona</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Cocona/Cocona.csproj
+++ b/src/Cocona/Cocona.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <ImplicitUsings>true</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/test/Cocona.Lite.Test/Cocona.Lite.Test.csproj
+++ b/test/Cocona.Lite.Test/Cocona.Lite.Test.csproj
@@ -7,7 +7,7 @@
     <NoWarn>$(NoWarn);1701;1702;CS1998</NoWarn>
     <Nullable>annotations</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/test/Cocona.Test/Cocona.Test.csproj
+++ b/test/Cocona.Test/Cocona.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Cocona\StrongNameKey.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
## Summary

- ライブラリ3プロジェクト + テスト2プロジェクトの TargetFrameworks に `net10.0` を追加
- `global.json` の SDK バージョンを `10.0.100` に更新
- CI (`ci.yml`) に `10.0.x` SDK を追加
- `publish.yml` の `6.0.x` を削除し `10.0.x` を追加（#13 の対応漏れ修正含む）
- README.md の Requirements に `.NET 10` を追加

## Test plan

- [x] `dotnet format --verify-no-changes` — フォーマット違反なし
- [x] `dotnet build -c Release` — 全ターゲット（net10.0, net8.0, netstandard2.0, netstandard2.1）でビルド成功（0 errors）
- [x] `dotnet test -c Release` — net10.0 で全765テスト通過（Cocona.Test: 565, Cocona.Lite.Test: 200）
- [x] CI green（net8.0 のテストは CI で検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)