### PR TITLE
Add Dependabot config for NuGet and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "main"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "main"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"


### PR DESCRIPTION
## Background

依存パッケージのバージョン管理が手動運用のままだった。NuGet パッケージと GitHub Actions の両方で、破壊的変更を含む major アップデートを見落とさない仕組みが必要になった。

Closes #23

## Approach

GitHub 標準の Dependabot を採用し、`.github/dependabot.yml` で宣言的に管理する。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: Dependabot (採用) | GitHub ネイティブ、設定ファイルのみで完結 | ignore ルールが冗長になりやすい |
| B: Renovate | 柔軟なマージポリシー、グルーピング機能 | 外部 App の導入が必要、設定が複雑 |

### 採用理由

単一リポジトリで major のみ追跡するシンプルな要件に対し、外部依存なしで完結する Dependabot が最適と判断した。

## What Changed

### Dependabot 設定の追加

- `.github/dependabot.yml` — NuGet と GitHub Actions の2エコシステムを対象に、monthly スケジュール・major のみの更新 PR を生成する設定

設定のポイント:
- `target-branch: "main"` で main ブランチに対して PR を作成
- `ignore` で minor/patch を除外し、major アップデートのみ通知

## Tradeoffs and Limitations

- **minor/patch の見落とし**: セキュリティ修正が minor/patch に含まれる場合、Dependabot security updates（別機能）でカバーされるが、通常の更新 PR としては上がってこない
- **月1回の頻度**: 緊急性の高い major 変更への反応は最大1ヶ月遅れる

## Testing

設定ファイルの追加のみのため、機能テストは不要。Dependabot が正しく動作するかは、次回のスケジュール実行（月次）で確認される。

## Review Guide

1. `.github/dependabot.yml` — 設定ファイル1つのみ。ignore ルールが意図通り minor/patch を除外しているか確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)