### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- CS1591: Missing XML comment for publicly visible type or member '...' -->


### PR DESCRIPTION
## Background

v1.0.0 以降、.NET 6.0 削除・.NET 10 移行・CI/CD 刷新・Dependabot 導入と多くの変更が蓄積された。これらを v2.0.0 としてリリースするため、`VersionPrefix` を更新する。

#15 (.NET 11 サポート) は GA (2026年11月) 待ちのため、v2.0 のリリースをブロックしない。

Closes #22

## Approach

`src/Directory.Build.props` の `VersionPrefix` を `1.0.0` → `2.0.0` に変更するのみ。タグ打ち・GitHub Release 作成はマージ後に手動で行う。

## What Changed

### バージョン番号の更新

- `src/Directory.Build.props` — `VersionPrefix` を `2.0.0` に変更

## Tradeoffs and Limitations

- **.NET 6.0 の破壊的変更**: v2.0.0 は .NET 6.0 をサポートしない。.NET 6.0 ユーザーは v1.x を継続利用する必要がある

## Testing

ビルド・テスト (765 tests passed on net10.0) をローカルで確認済み。CI でも検証される。

## Review Guide

1. `src/Directory.Build.props` — 変更は `VersionPrefix` の1行のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)